### PR TITLE
Add syncnull() function

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -29,7 +29,7 @@ var Fiber = require('fibers');
  *
  */
 Function.prototype.sync = function(obj /* arguments */) {
-    
+
     var fiber = Fiber.current,
         err, result,
         yielded = false;
@@ -39,7 +39,7 @@ Function.prototype.sync = function(obj /* arguments */) {
         // forbid to call twice
         if (syncCallback.called) return;
         syncCallback.called = true;
-        
+
         if (callbackError) {
             err = callbackError;
         }
@@ -53,30 +53,86 @@ Function.prototype.sync = function(obj /* arguments */) {
         else {
             result = callbackResult;
         }
-        
+
         // Resume fiber if yielding
         if (yielded) fiber.run();
     }
-    
+
     // Prepare args (remove first arg and add callback to the end)
     // The cycle is used because of slow v8 arguments materialization
     for (var i = 1, args = [], l = arguments.length; i < l; i++) {
         args.push(arguments[i]);
     }
     args.push(syncCallback);
-    
+
     // call async function
     this.apply(obj, args);
-    
+
     // wait for result
     if (!syncCallback.called) {
         yielded = true;
         Fiber.yield();
     }
-    
+
     // Throw if err
     if (err) throw err;
-    
+
+    return result;
+}
+
+/**
+ * Syntaxic sugar for sync(null, ...args...)
+ */
+Function.prototype.syncnull = function(/* arguments */) {
+
+    var fiber = Fiber.current,
+        err, result,
+        yielded = false,
+        obj = null;
+
+    // Create virtual callback
+    var syncCallback = function (callbackError, callbackResult, otherArgs) {
+        // forbid to call twice
+        if (syncCallback.called) return;
+        syncCallback.called = true;
+
+        if (callbackError) {
+            err = callbackError;
+        }
+        else if (otherArgs) {
+            // Support multiple callback result values
+            result = [];
+            for (var i = 1, l = arguments.length; i < l; i++) {
+                result.push(arguments[i]);
+            }
+        }
+        else {
+            result = callbackResult;
+        }
+
+        // Resume fiber if yielding
+        if (yielded) fiber.run();
+    }
+
+    // Prepare args (remove first arg and add callback to the end)
+    // The cycle is used because of slow v8 arguments materialization
+    for (var i = 0, args = [], l = arguments.length; i < l; i++) {
+        args.push(arguments[i]);
+    }
+    args.push(syncCallback);
+
+    // call async function
+    this.apply(obj, args);
+
+    // wait for result
+    if (!syncCallback.called) {
+        yielded = true;
+        Fiber.yield();
+    }
+
+    // Throw if err
+    if (err) throw err;
+
     return result;
 }
 
@@ -88,7 +144,7 @@ var Sync = function Sync(fn, callback)
     if (fn instanceof Function) {
         return Sync.Fiber(fn, callback);
     }
-    
+
     // TODO: we can also wrap any object with Sync, in future..
 }
 
@@ -107,72 +163,72 @@ Sync.Fiber = function SyncFiber(fn, callback)
 {
     var parent = Fiber.current;
     Sync.stat.totalFibers++;
-    
+
     var traceError = new Error();
     if (parent) {
         traceError.__previous = parent.traceError;
     }
-    
+
     var fiber = Fiber(function(){
-        
+
         Sync.stat.activeFibers++;
-        
+
         var fiber = Fiber.current,
             result,
             error;
-        
+
         // Set id to fiber
         fiber.id = Sync.stat.totalFibers;
-        
+
         // Save the callback to fiber
         fiber.callback = callback;
-        
+
         // Register trace error to the fiber
         fiber.traceError = traceError;
-        
+
         // Initialize scope
         fiber.scope = {};
-        
+
         // Assign parent fiber
         fiber.parent = parent;
-        
+
         // Fiber string representation
         fiber.toString = function() {
             return 'Fiber#' + fiber.id;
         }
-        
+
         // Fiber path representation
         fiber.getPath = function() {
             return (fiber.parent ? fiber.parent.getPath() + ' > ' : '' )
                 + fiber.toString();
         }
-        
+
         // Inherit scope from parent fiber
         if (parent) {
             fiber.scope.__proto__ = parent.scope;
         }
-        
+
         // Add futures support to a fiber
         fiber.futures = [];
-        
+
         fiber.waitFutures = function() {
             var results = [];
             while (fiber.futures.length)
                 results.push(fiber.futures.shift().result);
             return results;
         }
-        
+
         fiber.removeFuture = function(ticket) {
             var index = fiber.futures.indexOf(ticket);
             if (~index)
                 fiber.futures.splice(index, 1);
         }
-        
+
         fiber.addFuture = function(ticket) {
             fiber.futures.push(ticket);
         }
-        
-        // Run body    
+
+        // Run body
         try {
             // call fn and wait for result
             result = fn(Fiber.current);
@@ -182,9 +238,9 @@ Sync.Fiber = function SyncFiber(fn, callback)
         catch (e) {
             error = e;
         }
-        
+
         Sync.stat.activeFibers--;
-        
+
         // return result to the callback
         if (callback instanceof Function) {
             callback(error, result);
@@ -196,9 +252,9 @@ Sync.Fiber = function SyncFiber(fn, callback)
             // TODO: what to do with such errors?
             // throw error;
         }
-        
+
     });
-    
+
     fiber.run();
 }
 
@@ -208,32 +264,32 @@ Sync.Fiber = function SyncFiber(fn, callback)
 function SyncFuture(timeout)
 {
     var self = this;
-    
+
     this.resolved = false;
     this.fiber = Fiber.current;
     this.yielding = false;
     this.timeout = timeout;
     this.time = null;
-    
+
     this._timeoutId = null;
     this._result = undefined;
     this._error = null;
     this._start = +new Date;
-    
+
     Sync.stat.totalFutures++;
     Sync.stat.activeFutures++;
-    
+
     // Create timeout error to capture stack trace correctly
     self.timeoutError = new Error();
     Error.captureStackTrace(self.timeoutError, arguments.callee);
-    
+
     this.ticket = function Future()
     {
         // clear timeout if present
         if (self._timeoutId) clearTimeout(self._timeoutId);
         // measure time
         self.time = new Date - self._start;
-        
+
         // forbid to call twice
         if (self.resolved) return;
         self.resolved = true;
@@ -246,11 +302,11 @@ function SyncFuture(timeout)
         else {
             self._result = arguments[1];
         }
-        
+
         // remove self from current fiber
         self.fiber.removeFuture(self.ticket);
         Sync.stat.activeFutures--;
-        
+
         if (self.yielding && Fiber.current !== self.fiber) {
             self.yielding = false;
             self.fiber.run();
@@ -259,9 +315,9 @@ function SyncFuture(timeout)
             throw self._error;
         }
     }
-    
+
     this.ticket.__proto__ = this;
-    
+
     this.ticket.yield = function() {
         while (!self.resolved) {
             self.yielding = true;
@@ -276,11 +332,11 @@ function SyncFuture(timeout)
         if (self._error) throw self._error;
         return self._result;
     }
-    
+
     this.ticket.__defineGetter__('result', function(){
         return this.yield();
     });
-    
+
     this.ticket.__defineGetter__('error', function(){
         if (self._error) {
             return self._error;
@@ -293,18 +349,18 @@ function SyncFuture(timeout)
         }
         return null;
     });
-    
+
     this.ticket.__defineGetter__('timeout', function(){
         return self.timeout;
     });
-    
+
     this.ticket.__defineSetter__('timeout', function(value){
         self.timeout = value;
     });
-    
+
     // append self to current fiber
     this.fiber.addFuture(this.ticket);
-    
+
     return this.ticket;
 }
 
@@ -317,7 +373,7 @@ Sync.Future = SyncFuture;
  *
  */
 Function.prototype.future = function(obj /* arguments */) {
-    
+
     var fn = this,
         future = new SyncFuture();
 
@@ -328,10 +384,10 @@ Function.prototype.future = function(obj /* arguments */) {
     }
     // virtual future callback, push it as last argument
     args.push(future);
-    
+
     // call async function
     fn.apply(obj, args);
-    
+
     return future;
 }
 
@@ -342,9 +398,9 @@ Function.prototype.future = function(obj /* arguments */) {
 Function.prototype.async = function(context)
 {
     var fn = this, fiber = Fiber.current;
-    
+
     function asyncFunction() {
-        
+
         // Prepare args (remove first arg and add callback to the end)
         // The cycle is used because of slow v8 arguments materialization
         for (var i = 0, args = [], l = arguments.length; i < l; i++) {
@@ -354,14 +410,14 @@ Function.prototype.async = function(context)
         var obj = context || this,
             cb = args.pop(),
             async = true;
-        
+
         if (typeof(cb) !== 'function') {
             args.push(cb);
             if (Fiber.current) async = false;
         }
-        
+
         Fiber.current = Fiber.current || fiber;
-        
+
         // Call asynchronously
         if (async) {
             Sync(function(){
@@ -373,7 +429,7 @@ Function.prototype.async = function(context)
             return fn.apply(obj, args);
         }
     }
-    
+
     // Do nothing on async again
     asyncFunction.async = function() {
         return asyncFunction;
@@ -389,13 +445,13 @@ Function.prototype.async = function(context)
     asyncFunction.toString = function() {
 		return fn + '.async()';
 	}
-    
+
     return asyncFunction;
 }
 
 /**
  * Used for writing synchronous middleware-style functions
- * 
+ *
  * throw "something" --> next('something')
  * return --> next()
  * return null --> next()
@@ -433,11 +489,11 @@ Sync.sleep = function(ms)
     if (!fiber) {
         throw new Error('Sync.sleep() can be called only inside of fiber');
     }
-    
+
     setTimeout(function(){
         fiber.run();
     }, ms);
-    
+
     Fiber.yield();
 }
 
@@ -458,12 +514,12 @@ Sync.log = function(err, result)
  * Synchronous repl implementation: each line = new fiber
  */
 Sync.repl = function() {
-    
+
     var repl = require('repl');
-    
+
     // Start original repl
     var r = repl.start.apply(repl, arguments);
-    
+
     // Wrap line watchers with Fiber
     var newLinsteners = []
     r.rli.listeners('line').map(function(f){
@@ -478,10 +534,10 @@ Sync.repl = function() {
     while (newLinsteners.length) {
         r.rli.on('line', newLinsteners.shift());
     }
-    
+
     // Assign Sync to repl context
     r.context.Sync = Sync;
-    
+
     return r;
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -5,15 +5,15 @@
 
 var fs = require('fs');
 
-var tests = ['fiber', 'sync', 'async', 'future', 'sleep'];
+var tests = ['fiber', 'sync', 'syncnull', 'async', 'future', 'sleep'];
 var i = 0;
 tests.forEach(function(name){
-    
+
     var test = require('./' + name);
     test(function(err){
         if (err) console.log('test %s failed', name);
         else console.log('%s passed', name);
-        
+
         if (++i == tests.length) {
             console.log('done');
         }

--- a/test/syncnull.js
+++ b/test/syncnull.js
@@ -1,0 +1,155 @@
+
+/**
+ * Tests for Function.prototype.sync
+ */
+
+var Sync = require('..'),
+    assert = require('assert');
+
+// Simple asynchronous function
+function asyncFunction(a, b, callback) {
+    process.nextTick(function(){
+        callback(null, a + b);
+    })
+}
+
+// Simple asynchronous function which invokes callback in the same tick
+function asyncFunctionSync(a, b, callback) {
+    callback(null, a + b);
+}
+
+// Simple asynchronous function returning a value synchronously
+function asyncFunctionReturningValue(a, b, callback) {
+    process.nextTick(function(){
+        callback(null, a + b);
+    })
+    return 123;
+}
+
+// Asynchronous which returns multiple arguments to a callback and returning a value synchronously
+function asyncFunctionReturningValueMultipleArguments(a, b, callback) {
+    process.nextTick(function(){
+        callback(null, a, b);
+    })
+    return 123;
+}
+
+// Simple asynchronous function which throws an exception
+function asyncFunctionThrowsException(a, b, callback) {
+    process.nextTick(function(){
+        callback('something went wrong');
+    })
+}
+
+// Simple asynchronous function which throws an exception in the same tick
+function asyncFunctionThrowsExceptionSync(a, b, callback) {
+    callback('something went wrong');
+}
+
+// Simple asynchronous function which throws an exception and returning a value synchronously
+function asyncFunctionReturningValueThrowsException(a, b, callback) {
+    process.nextTick(function(){
+        callback('something went wrong');
+    })
+    return 123;
+}
+
+// Wrong asynchronous which calls callback twice
+function asyncFunctionCallbackTwice(a, b, callback) {
+    process.nextTick(function(){
+        callback(null, a + b);
+        callback(null, a - b);
+    })
+}
+
+// Asynchronous which returns multiple arguments to a callback
+function asyncFunctionMultipleArguments(a, b, callback) {
+    process.nextTick(function(){
+        callback(null, a, b);
+    })
+}
+
+// test object
+var testObject = {
+
+    property : 2,
+
+    asyncMethod : function someAsyncMethod(b, callback) {
+        var self = this;
+        process.nextTick(function(){
+            callback(null, self.property + b);
+        })
+    },
+
+    asyncMethodThrowsException : function someAsyncMethodThrowsException(b, callback) {
+        process.nextTick(function(){
+            callback('something went wrong');
+        })
+    },
+
+    asyncMethodMultipleArguments : function asyncMethodMultipleArguments(b, callback) {
+        var self = this;
+        process.nextTick(function(){
+            callback(null, self.property, b);
+        })
+    }
+}
+
+var runTest = module.exports = function(callback)
+{
+    Sync(function(){
+
+        // test on returning value
+        var result = asyncFunction.syncnull(2, 3);
+        assert.equal(result, 2 + 3);
+
+        // test on returning value in the same tick
+        var result = asyncFunctionSync.syncnull(2, 3);
+        assert.equal(result, 2 + 3);
+
+        // test on throws exception
+        assert.throws(function(){
+            var result = asyncFunctionThrowsException.syncnull(2, 3);
+        }, 'something went wrong');
+
+        // test on throws exception in the same tick
+        assert.throws(function(){
+            var result = asyncFunctionThrowsExceptionSync.syncnull(2, 3);
+        }, 'something went wrong');
+
+        // test asynchronous function should not return a synchronous value
+        var result = asyncFunctionReturningValue.syncnull(2, 3);
+        assert.equal(result, 2 + 3);
+
+        // test returning multiple arguments
+        var result = asyncFunctionMultipleArguments.syncnull(2, 3);
+        assert.deepEqual(result, [2, 3]);
+
+        // test asynchronous function should not return a synchronous value (multiple arguments)
+        var result = asyncFunctionReturningValueMultipleArguments.syncnull(2, 3);
+        assert.deepEqual(result, [2, 3]);
+
+        // test asynchronous function should not return a synchronous value (throwing exception)
+        assert.throws(function(){
+            var result = asyncFunctionReturningValueThrowsException.syncnull(2, 3);
+        }, 'something went wrong');
+
+        // test asynchronous which calls callback twice (should not be called twice)
+        var result = asyncFunctionCallbackTwice.syncnull(2, 3);
+        assert.equal(result, 2 + 3);
+
+    }, function(e){
+        if (e) {
+            console.error(e.stack);
+        }
+        if (callback) {
+            callback(e);
+        }
+    })
+}
+
+if (!module.parent) {
+    runTest(function(){
+        console.log('%s done', __filename);
+    });
+}


### PR DESCRIPTION
Синтаксический сахар. Функция `syncnull()` полностью аналогична `sync()` за исключением того, что не требует первого аргумента, а подставляет вместо него null.

``` js
var sum = function(a, b){
    return a+b;
}.async();

result = sum.syncnull(2, 3); // аналогично: sum.sync(null, 2, 3);
```

Самый кайф в том, что с `syncnull()` функция, складывающая два числа, теперь и при объявлении, и при вызове принимает ровно два аргумента. Асинхронный код становится ещё больше похожим на синхронный.
