### PR TITLE
Add repository field to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,9 @@
     },
     "dependencies" : {
         "fibers": ">=0.6"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/0ctave/node-sync.git"
     }
 }


### PR DESCRIPTION
Without the repository field, npm prints this warning:

```
npm WARN package.json sync@0.2.2 No repository field.
```
