### PR TITLE
Updated package.json for newer NodeJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "node": ">=0.5.2"
   },
   "dependencies": {
-    "fibers": "0.6.8"
+    "fibers": ">=0.6"
   }
 }


### PR DESCRIPTION
In Node JS > 0.11.x, fibers version 0.6.8 cannot be compiled. Therefore the package.json needs to be updated to tu use fibers ">=0.6"