### PR TITLE
throw error instead of silently ignore

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -194,7 +194,7 @@ Sync.Fiber = function SyncFiber(fn, callback)
         }
         else if (error) {
             // TODO: what to do with such errors?
-            // throw error;
+            throw error;
         }
         
     });


### PR DESCRIPTION
I was debugging my app and had no idea what happens, script just didn't execute some lines.
Then I added console.log('step1'), console.log('step2') etc. after each line and found that script stops on certain step and don't output anything. However I added try ... catch block around. After some research I solved it with removing commented line in sync.js.