### PR TITLE
Lock fibers version to ^3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "node": ">=0.5.2"
   },
   "dependencies": {
-    "fibers": ">=0.6"
+    "fibers": "^3.1.1"
   }
 }


### PR DESCRIPTION
# Summary

Fibers just release version 4.x.x few days ago, which require node version 10. Which make installation with yarn failed.

We need to make it saver by limit the fibers depedencies to ^3.1.1 only